### PR TITLE
only allow timezone aware indices, so conversion to timestamps is always correctly UTC

### DIFF
--- a/meteo_qc/_main.py
+++ b/meteo_qc/_main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
+from datetime import tzinfo
 from typing import TypedDict
 
 import pandas as pd
@@ -98,6 +99,9 @@ def apply_qc(df: pd.DataFrame, column_mapping: ColumnMapping) -> FinalResult:
             f'the pandas.DataFrame index must be of type pandas.DatetimeIndex,'
             f' not {type(df.index)}',
         )
+    elif not isinstance(df.index.tzinfo, tzinfo):
+        raise TypeError('the pandas.DataFrame index must be timezone aware')
+
     final_res: FinalResult = {
         'columns': defaultdict(
             lambda: {'results': {}, 'passed': False},


### PR DESCRIPTION
Timezones can be a nightmare, especially when you're dealing with string dates and timestamps. This tries to address this problem by forcing the user to explicitly define the timezone of the data, so we can make sure that the returned timestamps are properly in UTC only.